### PR TITLE
WIP: windows builder provisioning

### DIFF
--- a/support/cygwin_juliadev.ps1
+++ b/support/cygwin_juliadev.ps1
@@ -5,9 +5,11 @@ foreach ($pkg in @("git,make,curl,patch,python,gcc-g++,m4,cmake,p7zip",
     "mingw64-i686-gcc-g++,mingw64-i686-gcc-fortran",
     "mingw64-x86_64-gcc-g++,mingw64-x86_64-gcc-fortran")) {
   C:\cygwin\setup-x86_64.exe -q -n -R C:\cygwin -l C:\cygwin\packages `
-    -s http://mirror.mcs.anl.gov/cygwin -g -P $pkg | Where-Object `
+    -s http://mirrors.chauf.net/cygwin -g -P $pkg | Where-Object `
     -FilterScript {$_ -notlike "Installing file *"} | Write-Output
 }
+[Environment]::SetEnvironmentVariable("HOMEDRIVE", "C:")
+[Environment]::SetEnvironmentVariable("HOMEPATH", "\Users\vagrant")
 C:\cygwin\bin\sh -lc "if ! [ -e julia32 ]; then git clone \
   git://github.com/JuliaLang/julia.git julia32; fi && cd julia32 && \
   git submodule init && git pull && git submodule update && \

--- a/support/cygwin_juliadev.ps1
+++ b/support/cygwin_juliadev.ps1
@@ -1,0 +1,14 @@
+(new-object net.webclient).DownloadFile("http://cygwin.com/setup-x86_64.exe", "C:\cygwin\setup-x86_64.exe")
+foreach ($pkg in @("make","curl","patch","python","gcc-g++","m4","p7zip",
+    "mingw64-i686-gcc-g++","mingw64-i686-gcc-fortran",
+    "mingw64-x86_64-gcc-g++","mingw64-x86_64-gcc-fortran")) {
+  Write-Host $("Installing "+$pkg)
+  & C:\cygwin\setup-x86_64.exe -q -n -g -P $pkg >$null 2>&1
+}
+& git config --global core.autocrlf input
+C:\cygwin\bin\sh -lc "git clone git://github.com/JuliaLang/julia.git julia32 && \
+  cd julia32 && git submodule init && git submodule update && \
+  XC_HOST=i686-w64-mingw32 make -j2 -C deps"
+C:\cygwin\bin\sh -lc "git clone git://github.com/JuliaLang/julia.git julia64 && \
+  cd julia64 && git submodule init && git submodule update && \
+  XC_HOST=x86_64-w64-mingw32 make -j2 -C deps"

--- a/support/cygwin_juliadev.ps1
+++ b/support/cygwin_juliadev.ps1
@@ -1,12 +1,13 @@
+mkdir -Force C:\cygwin | Out-Null
 (new-object net.webclient).DownloadFile(
   "http://cygwin.com/setup-x86_64.exe", "C:\cygwin\setup-x86_64.exe")
-foreach ($pkg in @("make","curl","patch","python","gcc-g++","m4","p7zip",
-    "mingw64-i686-gcc-g++","mingw64-i686-gcc-fortran",
-    "mingw64-x86_64-gcc-g++","mingw64-x86_64-gcc-fortran")) {
-  Write-Host $("Installing "+$pkg)
-  & C:\cygwin\setup-x86_64.exe -q -n -g -P $pkg >$null 2>&1
+foreach ($pkg in @("git,make,curl,patch,python,gcc-g++,m4,p7zip",
+    "mingw64-i686-gcc-g++,mingw64-i686-gcc-fortran",
+    "mingw64-x86_64-gcc-g++,mingw64-x86_64-gcc-fortran")) {
+  C:\cygwin\setup-x86_64.exe -q -n -R C:\cygwin -l C:\cygwin\packages `
+    -s http://mirror.mcs.anl.gov/cygwin -g -P $pkg | Where-Object `
+    -FilterScript {$_ -notlike "Installing file *"} | Write-Output
 }
-C:\cygwin\bin\sh -lc "git config --global core.autocrlf input"
 C:\cygwin\bin\sh -lc "if ! [ -e julia32 ]; then git clone \
   git://github.com/JuliaLang/julia.git julia32; fi && \
   cd julia32 && git submodule init && git pull && \

--- a/support/cygwin_juliadev.ps1
+++ b/support/cygwin_juliadev.ps1
@@ -1,7 +1,7 @@
 mkdir -Force C:\cygwin | Out-Null
 (new-object net.webclient).DownloadFile(
   "http://cygwin.com/setup-x86_64.exe", "C:\cygwin\setup-x86_64.exe")
-foreach ($pkg in @("git,make,curl,patch,python,gcc-g++,m4,p7zip",
+foreach ($pkg in @("git,make,curl,patch,python,gcc-g++,m4,cmake,p7zip",
     "mingw64-i686-gcc-g++,mingw64-i686-gcc-fortran",
     "mingw64-x86_64-gcc-g++,mingw64-x86_64-gcc-fortran")) {
   C:\cygwin\setup-x86_64.exe -q -n -R C:\cygwin -l C:\cygwin\packages `
@@ -16,5 +16,5 @@ C:\cygwin\bin\sh -lc "if ! [ -e julia32 ]; then git clone \
 C:\cygwin\bin\sh -lc "if ! [ -e julia64 ]; then git clone \
   git://github.com/JuliaLang/julia.git julia64; fi && cd julia64 && \
   git submodule init && git pull && git submodule update && \
-  echo 'XC_HOST=x86_64-w64-mingw32' > Make.user && make cleanall && \
+  echo 'XC_HOST = x86_64-w64-mingw32' > Make.user && make cleanall && \
   make -j2 test && make win-extras && make dist"

--- a/support/cygwin_juliadev.ps1
+++ b/support/cygwin_juliadev.ps1
@@ -5,18 +5,16 @@ foreach ($pkg in @("git,make,curl,patch,python,gcc-g++,m4,cmake,p7zip",
     "mingw64-i686-gcc-g++,mingw64-i686-gcc-fortran",
     "mingw64-x86_64-gcc-g++,mingw64-x86_64-gcc-fortran")) {
   C:\cygwin\setup-x86_64.exe -q -n -R C:\cygwin -l C:\cygwin\packages `
-    -s http://mirrors.chauf.net/cygwin -g -P $pkg | Where-Object `
+    -s http://mirrors.mit.edu/cygwin -g -P $pkg | Where-Object `
     -FilterScript {$_ -notlike "Installing file *"} | Write-Output
 }
 [Environment]::SetEnvironmentVariable("HOMEDRIVE", "C:")
 [Environment]::SetEnvironmentVariable("HOMEPATH", "\Users\vagrant")
 C:\cygwin\bin\sh -lc "if ! [ -e julia32 ]; then git clone \
-  git://github.com/JuliaLang/julia.git julia32; fi && cd julia32 && \
-  git submodule init && git pull && git submodule update && \
+  git://github.com/JuliaLang/julia.git julia32; fi && cd julia32 && git pull && \
   echo 'XC_HOST = i686-w64-mingw32' > Make.user && make cleanall && \
-  make -j2 test && make win-extras && make dist"
+  make -j2 test && make win-extras && make binary-dist"
 C:\cygwin\bin\sh -lc "if ! [ -e julia64 ]; then git clone \
-  git://github.com/JuliaLang/julia.git julia64; fi && cd julia64 && \
-  git submodule init && git pull && git submodule update && \
+  git://github.com/JuliaLang/julia.git julia64; fi && cd julia64 && git pull && \
   echo 'XC_HOST = x86_64-w64-mingw32' > Make.user && make cleanall && \
-  make -j2 test && make win-extras && make dist"
+  make -j2 test && make win-extras && make binary-dist"

--- a/support/cygwin_juliadev.ps1
+++ b/support/cygwin_juliadev.ps1
@@ -9,10 +9,12 @@ foreach ($pkg in @("git,make,curl,patch,python,gcc-g++,m4,p7zip",
     -FilterScript {$_ -notlike "Installing file *"} | Write-Output
 }
 C:\cygwin\bin\sh -lc "if ! [ -e julia32 ]; then git clone \
-  git://github.com/JuliaLang/julia.git julia32; fi && \
-  cd julia32 && git submodule init && git pull && \
-  git submodule update && XC_HOST=i686-w64-mingw32 make -C deps"
+  git://github.com/JuliaLang/julia.git julia32; fi && cd julia32 && \
+  git submodule init && git pull && git submodule update && \
+  echo 'XC_HOST = i686-w64-mingw32' > Make.user && make cleanall && \
+  make -j2 test && make win-extras && make dist"
 C:\cygwin\bin\sh -lc "if ! [ -e julia64 ]; then git clone \
-  git://github.com/JuliaLang/julia.git julia64; fi && \
-  cd julia64 && git submodule init && git pull && \
-  git submodule update && XC_HOST=x86_64-w64-mingw32 make -C deps"
+  git://github.com/JuliaLang/julia.git julia64; fi && cd julia64 && \
+  git submodule init && git pull && git submodule update && \
+  echo 'XC_HOST=x86_64-w64-mingw32' > Make.user && make cleanall && \
+  make -j2 test && make win-extras && make dist"

--- a/support/cygwin_juliadev.ps1
+++ b/support/cygwin_juliadev.ps1
@@ -1,14 +1,17 @@
-(new-object net.webclient).DownloadFile("http://cygwin.com/setup-x86_64.exe", "C:\cygwin\setup-x86_64.exe")
+(new-object net.webclient).DownloadFile(
+  "http://cygwin.com/setup-x86_64.exe", "C:\cygwin\setup-x86_64.exe")
 foreach ($pkg in @("make","curl","patch","python","gcc-g++","m4","p7zip",
     "mingw64-i686-gcc-g++","mingw64-i686-gcc-fortran",
     "mingw64-x86_64-gcc-g++","mingw64-x86_64-gcc-fortran")) {
   Write-Host $("Installing "+$pkg)
   & C:\cygwin\setup-x86_64.exe -q -n -g -P $pkg >$null 2>&1
 }
-& git config --global core.autocrlf input
-C:\cygwin\bin\sh -lc "git clone git://github.com/JuliaLang/julia.git julia32 && \
-  cd julia32 && git submodule init && git submodule update && \
-  XC_HOST=i686-w64-mingw32 make -j2 -C deps"
-C:\cygwin\bin\sh -lc "git clone git://github.com/JuliaLang/julia.git julia64 && \
-  cd julia64 && git submodule init && git submodule update && \
-  XC_HOST=x86_64-w64-mingw32 make -j2 -C deps"
+C:\cygwin\bin\sh -lc "git config --global core.autocrlf input"
+C:\cygwin\bin\sh -lc "if ! [ -e julia32 ]; then git clone \
+  git://github.com/JuliaLang/julia.git julia32; fi && \
+  cd julia32 && git submodule init && git pull && \
+  git submodule update && XC_HOST=i686-w64-mingw32 make -C deps"
+C:\cygwin\bin\sh -lc "if ! [ -e julia64 ]; then git clone \
+  git://github.com/JuliaLang/julia.git julia64; fi && \
+  cd julia64 && git submodule init && git pull && \
+  git submodule update && XC_HOST=x86_64-w64-mingw32 make -C deps"

--- a/win2012r2.vagrant
+++ b/win2012r2.vagrant
@@ -1,0 +1,8 @@
+# -*- mode: ruby -*-
+# vi: set ft=ruby :
+
+Vagrant.configure("2") do |config|
+  config.vm.box = "packer-windows/windows_2012_r2_virtualbox.box"
+  config.vm.communicator = "winrm"
+  config.vm.provision "shell", path: "support/cygwin_juliadev.ps1"
+end


### PR DESCRIPTION
ref https://github.com/staticfloat/julia-buildbot/issues/3

Not fully ready yet, but in case you want to have a look at it

For now my Vagrantfile is pretty much just
```
Vagrant.configure("2") do |config|
  config.vm.box = "opentable/win-2012r2-standard-amd64-nocm"
  config.vm.communicator = "winrm" # important!
  config.vm.provision "shell", path: "support/cygwin_juliadev.ps1"
  config.vm.network "public_network", bridge: 'eth0'
end
```
But I think to be proper about licenses we will need to figure out how to build our own vagrant boxes from authorized evaluation images.